### PR TITLE
feat: add isJson method to CurlHttpClient class to improve handling o…

### DIFF
--- a/src/curl-http-client.ts
+++ b/src/curl-http-client.ts
@@ -81,6 +81,11 @@ export class CurlHttpClient {
     });
   }
 
+  private static isJson(contentType: string): boolean {
+    return contentType && contentType.includes('application/json')
+      || contentType.includes('application/hal+json');
+  }
+
   private static handleResponse<T>(
     stdout: string,
     config: Config,
@@ -100,7 +105,7 @@ export class CurlHttpClient {
     // Attempt to parse the body as JSON if the content-type is 'application/json'
     let data: T | string;
     try {
-      if (headers['Content-Type'] && headers['Content-Type'].includes('application/json')) {
+      if (CurlHttpClient.isJson(headers['Content-Type']) && body.length > 0) {
         data = JSON.parse(body) as T;
       } else {
         data = body;


### PR DESCRIPTION
…f response content type

The `isJson` method is added to the `CurlHttpClient` class. This method checks if the provided content type is either 'application/json' or 'application/hal+json'. This method is used in the `handleResponse` method to determine if the response body should be parsed as JSON. This improves the handling of different content types in the client.